### PR TITLE
Fix Next button last chapter logic

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import { BookOpen, Menu, X, CheckCircle, Clock, Target, Users, Download, Code } from 'lucide-react';
+import { BookOpen, Menu, X, CheckCircle, Target, Download } from 'lucide-react';
 import Sidebar from './components/Sidebar';
 import ChapterContent from './components/ChapterContent';
 import ProgressTracker from './components/ProgressTracker';
@@ -105,6 +105,7 @@ function App() {
               <ChapterContent
                 chapter={chapters[validCurrentChapter]}
                 chapterIndex={validCurrentChapter}
+                totalChapters={chapters.length}
                 progress={currentProgress}
                 onProgressUpdate={updateProgress}
                 onNext={() => validCurrentChapter < chapters.length - 1 && setCurrentChapter(validCurrentChapter + 1)}

--- a/src/components/ChapterContent.tsx
+++ b/src/components/ChapterContent.tsx
@@ -7,6 +7,7 @@ import { Chapter, ChapterProgress } from '../types';
 interface ChapterContentProps {
   chapter: Chapter;
   chapterIndex: number;
+  totalChapters: number;
   progress: ChapterProgress;
   onProgressUpdate: (chapterIndex: number, completed: boolean, score?: number) => void;
   onNext: () => void;
@@ -16,6 +17,7 @@ interface ChapterContentProps {
 const ChapterContent: React.FC<ChapterContentProps> = ({
   chapter,
   chapterIndex,
+  totalChapters,
   progress,
   onProgressUpdate,
   onNext,
@@ -254,7 +256,7 @@ const ChapterContent: React.FC<ChapterContentProps> = ({
 
         <button
           onClick={onNext}
-          disabled={chapterIndex === 9} // Last chapter
+          disabled={chapterIndex === totalChapters - 1}
           className="flex items-center space-x-2 px-6 py-3 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
         >
           <span>Next</span>


### PR DESCRIPTION
## Summary
- pass totalChapters to `ChapterContent`
- use total chapters when disabling the Next button
- remove unused icons and update call site

## Testing
- `npm run lint`


